### PR TITLE
Pidcontrol

### DIFF
--- a/CARL_motor_controller/CARL_motor_controller.ino
+++ b/CARL_motor_controller/CARL_motor_controller.ino
@@ -337,24 +337,24 @@ void ser_routine() {
     in_byte1 = Serial.read();
     switch(in_byte1) {
       case 65: {//  'A' - Set new RPM values 
-        in_byte2 = Serial.read(); // left motor rpm, high byte
-        in_byte3 = Serial.read(); // left motor rpm, low byte
-        in_byte4 = Serial.read(); // right motor rpm, high byte
-        in_byte5 = Serial.read(); // right motor rpm, low byte
+        in_byte2 = Serial.read(); // left motor rpm, low byte of 16bit signed int
+        in_byte3 = Serial.read(); // left motor rpm, high byte of 16bit signed int
+        in_byte4 = Serial.read(); // right motor rpm, low byte of 16bit signed int
+        in_byte5 = Serial.read(); // right motor rpm, high byte of 16bit signed int
 
-        in_byte6 = Serial.read(); // left motor max count, high3 byte
-        in_byte7 = Serial.read(); // left motor max count, high2 byte
-        in_byte8 = Serial.read(); // left motor max count, high1 byte
-        in_byte9 = Serial.read(); // left motor max count, low byte
-        in_byte10 = Serial.read(); // right motor max count, high3 byte
-        in_byte11 = Serial.read(); // right motor max count, high2 byte
-        in_byte12 = Serial.read(); // right motor max count, high1 byte
-        in_byte13 = Serial.read(); // right motor max count, low byte
+        in_byte6 = Serial.read(); // left motor max count, high3 byte of 32bit unsigned int
+        in_byte7 = Serial.read(); // left motor max count, high2 byte of 32bit unsigned int
+        in_byte8 = Serial.read(); // left motor max count, high1 byte of 32bit unsigned int
+        in_byte9 = Serial.read(); // left motor max count, low byte of 32bit unsigned int
+        in_byte10 = Serial.read(); // right motor max count, high3 byte of 32bit unsigned int
+        in_byte11 = Serial.read(); // right motor max count, high2 byte of 32bit unsigned int
+        in_byte12 = Serial.read(); // right motor max count, high1 byte of 32bit unsigned int
+        in_byte13 = Serial.read(); // right motor max count, low byte of 32bit unsigned int
         
         max_enc1_count = ((in_byte6 << 24) | (in_byte7 << 16) | (in_byte8 << 8) | in_byte9);
         max_enc2_count = ((in_byte10 << 24) | (in_byte11 << 16) | (in_byte12 << 8) | in_byte13);
 
-        int motor_rpm = ((in_byte2 << 8) | (in_byte3));
+        int motor_rpm = ((in_byte3 << 8) | (in_byte2));
         
         if (motor_rpm < 0) {
           l_motor_dir = 0;
@@ -364,7 +364,7 @@ void ser_routine() {
         set_l_motor_rpm = (float(abs(motor_rpm)));
         
 
-        motor_rpm = ((in_byte4 << 8) | (in_byte5));
+        motor_rpm = ((in_byte5 << 8) | (in_byte4));
         if (motor_rpm < 0) {
           r_motor_dir = 0;
         } else {

--- a/CARL_motor_controller/CARL_motor_controller.ino
+++ b/CARL_motor_controller/CARL_motor_controller.ino
@@ -571,15 +571,25 @@ void ser_routine() {
       }
       case 71: {// 'G' - Update PID variables
         Serial.println("Updating PID variables.");
-        float pid_p, pid_i, pid_d;
-        in_byte2 = Serial.read(); // 
-        in_byte3 = Serial.read(); // 
-        in_byte4 = Serial.read(); // 
-        in_byte5 = Serial.read(); // 
+        long in_b2, in_b3, in_b4, in_b5, in_long;
 
-        pid_p = (float)((in_byte2 << 32) | (in_byte3 << 16) | (in_byte4 << 8) | in_byte5);
+        in_b2 = Serial.read(); // 
+        in_b3 = Serial.read(); // 
+        in_b4 = Serial.read(); // 
+        in_b5 = Serial.read(); // 
+        Serial.println(in_b2);
+        Serial.println(in_b3);
+        Serial.println(in_b4);
+        Serial.println(in_b5);
+        
+        in_long = (in_b5 << 24) | (in_b4 << 16) | (in_b3 << 8) | in_b2;
+        Serial.println(in_long);
+        float* p_pid = new float;
+        *p_pid = *(&in_long);
+
         Serial.print("New K_p value:");
-        Serial.println(pid_p);
+        Serial.println(*p_pid);
+        delete p_pid;
 
         while(Serial.read() > -1);
         break;
@@ -788,18 +798,6 @@ void loop() {
     ser_counter = 0;
     ser_routine();
 
-    Serial.print("\nset_l_motor_rpm: ");
-    Serial.println(set_l_motor_rpm);
-    Serial.print("l_motor_rpm: ");
-    Serial.println(l_motor_rpm);
-    Serial.print("l_motor_throttle: ");
-    Serial.println(l_motor_throttle);
-    Serial.print("set_r_motor_rpm: ");
-    Serial.println(set_r_motor_rpm);
-    Serial.print("r_motor_rpm: ");
-    Serial.println(r_motor_rpm);
-    Serial.print("r_motor_throttle: ");
-    Serial.println(r_motor_throttle);
   }
 
 }

--- a/unit_testing/test007_simplepidtest.py
+++ b/unit_testing/test007_simplepidtest.py
@@ -1,0 +1,49 @@
+# This test script issues a command to the Arduino to set both
+# motors to 10,000 RPM.  It then queries the current
+# RPM measurement from the Arduino several times, and prints it to the terminal
+#
+# After 5 seconds, this test script sets both motor RPMs to zero.
+
+import serial
+import time
+import os
+
+os.system('stty -F /dev/ttyACM0 115200 -parenb -parodd -cmspar cs8 hupcl -cstopb cread clocal -crtscts -ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr -icrnl -ixon -ixoff -iuclc -ixany -imaxbel -iutf8 -opost -olcuc -ocrnl onlcr -onocr -onlret -ofill -ofdel nl0 cr0 tab0 bs0 vt0 ff0 -isig -icanon -iexten -echo -echoe -echok -echonl -noflsh -xcase -tostop -echoprt -echoctl -echoke -flusho -extproc')
+
+serial_path = '/dev/ttyACM0'
+serial_baud = 115200
+serial_timeout = 1.5
+
+arduino = serial.Serial(serial_path, baudrate = serial_baud, timeout = serial_timeout)
+time.sleep(2)
+
+if(arduino):
+    print("Serial port opened successfully.")
+else:
+    print("Unable to open serial port.")
+
+# print("Clearing serial buffer...")
+# while(arduino.in_waiting):
+#     data = arduino.readline()
+
+# print("Serial queue cleared!")
+
+command = b'\x41\x27\x10\x27\x10' # ['A'][10,000][10,000]
+arduino.write(command)
+    
+# read_count = 0
+# while(read_count < 4):
+#     command = b'\x42' # ['B']
+#     arduino.write(command)
+#     data = arduino.readline()
+#     print(data)
+#     time.sleep(2)
+#     read_count += 1
+
+time.sleep(5)
+command = b'\x41\x00\x00\x00\x00' # ['A'][0][0]
+arduino.write(command)
+ 
+arduino.close()
+print("Test complete.")
+

--- a/unit_testing/test008_updatepidvar.py
+++ b/unit_testing/test008_updatepidvar.py
@@ -27,14 +27,22 @@ while(arduino.in_waiting):
 print("Serial queue cleared!")
 
 
-pid_p = 0.002
+pid_p = 0.004
+pid_i = 0.005
+pid_d = 0.006
 
-ba = bytearray(struct.pack("f", pid_p))
-
-command = b'\x47' # ['G']
+command = b'\x47' + bytes((str(pid_p)+"\n"), 'UTF-8')  # ['G'][pid_p][\n]
 arduino.write(command)
-for elem in ba:
-    arduino.write((elem.to_bytes(1, byteorder='little')))
- 
+
+time.sleep(.6)
+
+command = b'\x48' + bytes((str(pid_i)+"\n"), 'UTF-8')  # ['H'][pid_i][\n]
+arduino.write(command)
+
+time.sleep(.6)
+
+command = b'\x49' + bytes((str(pid_d)+"\n"), 'UTF-8')  # ['I'][pid_d][\n]
+arduino.write(command)
+
 arduino.close()
 print("Test complete.")

--- a/unit_testing/test008_updatepidvar.py
+++ b/unit_testing/test008_updatepidvar.py
@@ -1,4 +1,4 @@
-# This test script issues a command ("G") to the Arduino to update the PID variables
+# This test script issues commands "G", "H" and "I" to the Arduino to update the PID variables
 
 import serial
 import time

--- a/unit_testing/test008_updatepidvar.py
+++ b/unit_testing/test008_updatepidvar.py
@@ -1,0 +1,40 @@
+# This test script issues a command ("G") to the Arduino to update the PID variables
+
+import serial
+import time
+import os
+import struct
+
+
+os.system('stty -F /dev/ttyACM0 115200 -parenb -parodd -cmspar cs8 hupcl -cstopb cread clocal -crtscts -ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr -icrnl -ixon -ixoff -iuclc -ixany -imaxbel -iutf8 -opost -olcuc -ocrnl onlcr -onocr -onlret -ofill -ofdel nl0 cr0 tab0 bs0 vt0 ff0 -isig -icanon -iexten -echo -echoe -echok -echonl -noflsh -xcase -tostop -echoprt -echoctl -echoke -flusho -extproc')
+
+serial_path = '/dev/ttyACM0'
+serial_baud = 115200
+serial_timeout = 1.5
+
+arduino = serial.Serial(serial_path, baudrate = serial_baud, timeout = serial_timeout)
+time.sleep(2)
+
+if(arduino):
+    print("Serial port opened successfully.")
+else:
+    print("Unable to open serial port.")
+
+print("Clearing serial buffer...")
+while(arduino.in_waiting):
+    data = arduino.readline()
+
+print("Serial queue cleared!")
+
+
+pid_p = 0.002
+
+ba = bytearray(struct.pack("f", pid_p))
+
+command = b'\x47' # ['G']
+arduino.write(command)
+for elem in ba:
+    arduino.write((elem.to_bytes(1, byteorder='little')))
+ 
+arduino.close()
+print("Test complete.")

--- a/unit_testing/test009_setrpmandduration.py
+++ b/unit_testing/test009_setrpmandduration.py
@@ -1,0 +1,71 @@
+# This script tests out the "A" command by having the host computer send the command,
+# along with RPM stet points and total (1/3)rotations desired.
+#
+# The "total (1/3) rotations desired", divided by 3, and multiplied by (Pi * r_wheel^2) 
+# should give target distance traveled by the wheel. Alternatively, start with target distance
+# to traverse, multiply by (3 / (Pi*r_wheel^2)) to determine total (1/3)rotations 
+# desired.
+
+from click import command
+import serial
+import time
+import os
+import math
+import numpy as np
+import struct
+
+
+os.system('stty -F /dev/ttyACM0 115200 -parenb -parodd -cmspar cs8 hupcl -cstopb cread clocal -crtscts -ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr -icrnl -ixon -ixoff -iuclc -ixany -imaxbel -iutf8 -opost -olcuc -ocrnl onlcr -onocr -onlret -ofill -ofdel nl0 cr0 tab0 bs0 vt0 ff0 -isig -icanon -iexten -echo -echoe -echok -echonl -noflsh -xcase -tostop -echoprt -echoctl -echoke -flusho -extproc')
+
+serial_path = '/dev/ttyACM0'
+serial_baud = 115200
+serial_timeout = 1.5
+wheel_rad = 4.0005 # centimeters
+target_l_rpm = np.int16(15000)
+target_r_rpm = np.int16(15000)
+target_l_distance = 200 # centimeters
+target_r_distance = 200 # centimeters
+
+print("Left motor RPM set point (RPM): ")
+print(target_l_rpm)
+print("Left motor distance set point (cm): ") 
+print(target_l_distance)
+print("Right motor RPM set point (RPM): ")
+print(target_r_rpm)
+print("Right motor distance set point (cm): ") 
+print(target_r_distance)
+
+
+
+arduino = serial.Serial(serial_path, baudrate = serial_baud, timeout = serial_timeout)
+time.sleep(2)
+
+if(arduino):
+    print("Serial port opened successfully.")
+else:
+    print("Unable to open serial port.")
+
+print("Clearing serial buffer...")
+while(arduino.in_waiting):
+    data = arduino.readline()
+
+print("Serial queue cleared!")
+
+target_enc1_ticks = int((target_l_distance * (3.0 / (math.pi*(wheel_rad**2))))*248.98)
+target_enc2_ticks = int((target_r_distance * (3.0 / (math.pi*(wheel_rad**2))))*248.98)
+print("Targeted number of encoder1 ticks: ")
+print(target_enc1_ticks)
+print("Targeted number of encoder2 ticks: ")
+print(target_enc2_ticks)
+
+#ticks_ba = bytearray(struct.pack("i", target_enc_ticks))
+l_ticks_bytes = target_enc1_ticks.to_bytes(4, 'big')
+r_ticks_bytes = target_enc2_ticks.to_bytes(4, 'big')
+l_rpm_bytes = target_l_rpm.tobytes()
+r_rpm_bytes = target_r_rpm.tobytes()
+
+command = b'\x41' + l_rpm_bytes + r_rpm_bytes + l_ticks_bytes + r_ticks_bytes
+# print(command)
+arduino.write(command)
+time.sleep(.6)
+arduino.close()


### PR DESCRIPTION
Implemented 'A' serial command to allow host computer to set both target RPMs and target encoder 'ticks'.  This should allow host computer to tell both motors independently how many turns to rotate, and at what RPM to rotate at.